### PR TITLE
Feature/properties provider ux improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,19 @@ There are two classes available to choose from, depending on your use case:
 
    Set Driver properties as follows:
    1. `AwsCredentialsProviderClass=za.co.absa.loginsvc.athena.PropertiesLoginServiceProfileCredentialsProvider`
-   2. Define a (new) User property `ls_user` with your username
-   3. Define a (new) User property `ls_password` with your password (this will get masked and secured by DBeaver)
-   4. Define a (new) User property `ls_url` with value `<LS_URL_GOES_HERE>`
-   5. Define a (new) User property `ls_jwt2token_url` with value `<JWT2TOKEN_URL_GOES_HERE>`
-   6. Leave `AwsCredentialsProviderArguments` unset
+   2. Define a (new) User property `ls_url` with value `<LS_URL_GOES_HERE>`
+   3. Define a (new) User property `ls_jwt2token_url` with value `<JWT2TOKEN_URL_GOES_HERE>`
+   4. Leave `AwsCredentialsProviderArguments` unset
 
-   With this provider, DBeaver's standard username and password fields are ignored (User properties values are used instead).
-   You may enter e.g. `notused`/`notused` for username/password value.
+   By default, this provider will use DBeaver's native user/password fields. Tested to work with DBeaver 25.3.0.
+
+###### Alternative way to provide username/password
+   On the off chance that this behavior get compromised (as witnessed with `${password}` above), the provider will 
+   attempt to read from `ls_user` and `ls_password` user-defined properties instead if they are present 
+   (ignoring DBeaver's native fields in that case). 
+
+   User property `ls_password` with your password will get masked in the UI.
+
    
 ### How to release
  - Commit with final version in pom.xml (e.g. 1.2.3)

--- a/src/main/scala/za/co/absa/loginsvc/athena/PropertiesLoginServiceProfileCredentialsProvider.scala
+++ b/src/main/scala/za/co/absa/loginsvc/athena/PropertiesLoginServiceProfileCredentialsProvider.scala
@@ -20,6 +20,8 @@ import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider}
 import za.co.absa.loginsvc.athena.ctx.DriverContext
 import za.co.absa.loginsvc.athena.model.LoginServiceProperties
 
+import java.util.Properties
+
 class PropertiesLoginServiceProfileCredentialsProvider() extends AWSCredentialsProvider {
   println("=== PropertiesLoginServiceProfileCredentialsProvider ===")
 
@@ -32,30 +34,54 @@ class PropertiesLoginServiceProfileCredentialsProvider() extends AWSCredentialsP
   private val sessionManager: SessionManager = new SessionManager(None)
   private val credentialsPrintLimiter = new PrintFrequencyLimiter()
 
-  private def loadLsProperties: LoginServiceProperties = {
+  private[athena] def initializeDriverContextWithProperties(): Properties = {
     val props = DriverContext.get
     if (props == null)
       throw new IllegalStateException(
         "DriverContext not initialized. Make sure that your Athena driver class name is: za.co.absa.loginsvc.athena.driver.AthenaDelegatingDriver"
       )
 
-    val lsUsername = props.getProperty("ls_user")
-    val lsPassword = props.getProperty("ls_password")
-    val lsUrl = props.getProperty("ls_url")
-    val jwt2tokenUrl = props.getProperty("ls_jwt2token_url")
+    props
+  }
+
+  private def loadLsProperties: LoginServiceProperties = {
+    val props = initializeDriverContextWithProperties()
+
     val lsDebug = props.getProperty("ls_debug", "false").toBoolean
 
-    if (lsUsername == null || lsUsername.isEmpty)
-      throw new RuntimeException("Config field 'ls_user' is missing!")
-
-    if (lsPassword == null || lsPassword.isEmpty)
-      throw new RuntimeException("Config field 'ls_password' is missing!")
+    val lsUrl = props.getProperty("ls_url")
+    val jwt2tokenUrl = props.getProperty("ls_jwt2token_url")
 
     if (lsUrl == null || lsUrl.isEmpty)
       throw new RuntimeException("Config field 'ls_url' is missing!")
-
     if (jwt2tokenUrl == null || jwt2tokenUrl.isEmpty)
       throw new RuntimeException("Config field 'ls_jwt2token_url' is missing!")
+
+    val user = props.getProperty("user") // default UI field value
+    val lsUsername = props.getProperty("ls_user") // optional custom override
+
+    val password = props.getProperty("password") //
+    val lsPassword = props.getProperty("ls_password") // optional custom override
+
+
+    val usernameUsed = if (lsUsername == null || lsUsername.isEmpty) {
+      user
+    } else {
+      if (lsDebug) {
+        println(s"username override from ls_username is used: $lsUsername")
+      }
+      lsUsername
+    }
+
+    val passwordUsed = if (lsPassword == null || lsPassword.isEmpty) {
+      password
+    } else {
+      if (lsDebug) {
+        println(s"password override from ls_password is used: *** (${lsPassword.length} chars)")
+      }
+      lsPassword
+    }
+
 
     if (lsDebug) {
       for (key <- props.keySet().toArray()) {
@@ -68,14 +94,14 @@ class PropertiesLoginServiceProfileCredentialsProvider() extends AWSCredentialsP
       }
     }
 
-    LoginServiceProperties(lsUsername, lsPassword, lsUrl, jwt2tokenUrl, lsDebug)
+    LoginServiceProperties(usernameUsed, passwordUsed, lsUrl, jwt2tokenUrl, lsDebug)
   }
 
   override def getCredentials: AWSCredentials = {
     val lsProps = loadLsProperties
 
     val creds = sessionManager.getSessionCredentials(Some(lsProps)) // internally manages expiration and renewal
-    credentialsPrintLimiter.printIfNotTooSoon(s"getCredentials: using creds: ${creds.getAWSAccessKeyId}, ...")
+    credentialsPrintLimiter.printIfNotTooSoon(s"getCredentials: ${lsProps.user}/*** (${lsProps.pass.length} chars) -> using creds: ${creds.getAWSAccessKeyId}, ...")
     creds
   }
 

--- a/src/main/scala/za/co/absa/loginsvc/athena/PropertiesLoginServiceProfileCredentialsProvider.scala
+++ b/src/main/scala/za/co/absa/loginsvc/athena/PropertiesLoginServiceProfileCredentialsProvider.scala
@@ -31,7 +31,9 @@ class PropertiesLoginServiceProfileCredentialsProvider() extends AWSCredentialsP
   def setArguments(args: String): Unit =
     arguments = args
 
-  private val sessionManager: SessionManager = new SessionManager(None)
+  private[athena] def initializeSessionManager(): SessionManager = new SessionManager(None)
+
+  private val sessionManager: SessionManager = initializeSessionManager()
   private val credentialsPrintLimiter = new PrintFrequencyLimiter()
 
   private[athena] def initializeDriverContextWithProperties(): Properties = {
@@ -44,7 +46,7 @@ class PropertiesLoginServiceProfileCredentialsProvider() extends AWSCredentialsP
     props
   }
 
-  private def loadLsProperties: LoginServiceProperties = {
+  private[athena] def loadLsProperties: LoginServiceProperties = {
     val props = initializeDriverContextWithProperties()
 
     val lsDebug = props.getProperty("ls_debug", "false").toBoolean

--- a/src/test/scala/za/co/absa/loginsvc/athena/PropertiesLoginServiceProfileCredentialsProviderTest.scala
+++ b/src/test/scala/za/co/absa/loginsvc/athena/PropertiesLoginServiceProfileCredentialsProviderTest.scala
@@ -1,0 +1,134 @@
+package za.co.absa.loginsvc.athena
+
+import com.simba.athena.amazonaws.auth.{BasicAWSCredentials, BasicSessionCredentials}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.loginsvc.athena.model.LoginServiceProperties
+
+import java.util.Properties
+
+class PropertiesLoginServiceProfileCredentialsProviderTest extends AnyFlatSpec with Matchers with MockFactory {
+
+  behavior of "PropertiesLoginServiceProfileCredentialsProvider.getCredentials"
+
+  it should "call getCredentials with expected props - with overrides and debug" in {
+    val props = new java.util.Properties()
+    props.setProperty("ls_url", "http://example.com/ls")
+    props.setProperty("ls_jwt2token_url", "http://example.com/jwt2token")
+    props.setProperty("user", "defaultUser")
+    props.setProperty("password", "defaultPass")
+    props.setProperty("ls_user", "") // empty override should be ignored
+
+    val mockSessionManager = mock[SessionManager]
+    val provider = createProviderWithProps(props, Some(mockSessionManager))
+    val testCreds = new BasicSessionCredentials("one", "two", "three")
+
+    (mockSessionManager.getSessionCredentials _)
+      .expects(Some(LoginServiceProperties("defaultUser", "defaultPass", "http://example.com/ls", "http://example.com/jwt2token")))
+      .returns(testCreds)
+
+    provider.getCredentials shouldBe testCreds
+  }
+
+  it should "call getCredentials with expected props - simple happy case (no valid overrides, no debug)" in {
+    val props = new java.util.Properties()
+    props.setProperty("ls_url", "http://example.com/ls")
+    props.setProperty("ls_jwt2token_url", "http://example.com/jwt2token")
+
+    props.setProperty("user", "defaultUser")
+    props.setProperty("password", "defaultPass")
+    props.setProperty("ls_user", "overrideUser")
+    props.setProperty("ls_password", "overridePass")
+
+    props.setProperty("ls_debug", "true")
+
+    val mockSessionManager = mock[SessionManager]
+    val provider = createProviderWithProps(props, Some(mockSessionManager))
+    val testCreds = new BasicSessionCredentials("one", "two", "three")
+
+    (mockSessionManager.getSessionCredentials _)
+      .expects(Some(LoginServiceProperties("overrideUser", "overridePass", "http://example.com/ls", "http://example.com/jwt2token", debug = true)))
+      .returns(testCreds)
+
+    provider.getCredentials shouldBe testCreds
+  }
+
+  // these tests cover the internal state when loading, but not strictly necessary
+  behavior of "PropertiesLoginServiceProfileCredentialsProvider.loadLsProperties"
+
+  it should "load properties from DriverContext - simple happy case (no valid overrides, no debug)" in {
+    val props = new java.util.Properties()
+    props.setProperty("ls_url", "http://example.com/ls")
+    props.setProperty("ls_jwt2token_url", "http://example.com/jwt2token")
+    props.setProperty("user", "defaultUser")
+    props.setProperty("password", "defaultPass")
+    props.setProperty("ls_user", "") // empty override should be ignored
+    val provider = createProviderWithProps(props)
+
+    val lsProps = provider.loadLsProperties
+    lsProps.user shouldBe "defaultUser"
+    lsProps.pass shouldBe "defaultPass"
+    lsProps.lsUrl shouldBe "http://example.com/ls"
+    lsProps.jwt2tokenSvcUrl shouldBe "http://example.com/jwt2token"
+    lsProps.debug shouldBe false
+  }
+
+  it should "load properties from DriverContext - with overrides and debug" in {
+    val props = new java.util.Properties()
+    props.setProperty("ls_url", "http://example.com/ls")
+    props.setProperty("ls_jwt2token_url", "http://example.com/jwt2token")
+
+    props.setProperty("user", "defaultUser")
+    props.setProperty("password", "defaultPass")
+    props.setProperty("ls_user", "overrideUser")
+    props.setProperty("ls_password", "overridePass")
+
+    props.setProperty("ls_debug", "true")
+    val provider = createProviderWithProps(props)
+
+    val lsProps = provider.loadLsProperties
+
+    lsProps.user shouldBe "overrideUser"
+    lsProps.pass shouldBe "overridePass"
+    lsProps.lsUrl shouldBe "http://example.com/ls"
+    lsProps.jwt2tokenSvcUrl shouldBe "http://example.com/jwt2token"
+    lsProps.debug shouldBe true
+  }
+
+  it should "fail when there are required properties missing" in {
+    val props = new java.util.Properties()
+    val provider = createProviderWithProps(props)
+
+    (the[RuntimeException] thrownBy {
+      provider.loadLsProperties
+    }).getMessage should include(
+      "Config field 'ls_url' is missing!"
+    )
+
+    props.setProperty("ls_url", "http://example.com/ls")
+    val provider2 = createProviderWithProps(props)
+
+    (the[RuntimeException] thrownBy {
+      provider2.loadLsProperties
+    }).getMessage should include(
+      "Config field 'ls_jwt2token_url' is missing!"
+    )
+
+  }
+
+  private def createProviderWithProps(props: java.util.Properties, optSessionManager: Option[SessionManager] = None): PropertiesLoginServiceProfileCredentialsProvider = {
+    optSessionManager.fold {
+      new PropertiesLoginServiceProfileCredentialsProvider {
+        override def initializeDriverContextWithProperties(): Properties = props
+      }
+    }{ customSessionManager =>
+      new PropertiesLoginServiceProfileCredentialsProvider {
+        override def initializeDriverContextWithProperties(): Properties = props
+        override def initializeSessionManager(): SessionManager = customSessionManager
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR is a usability improvement over #5.
Now, the `ls_user` and `ls_password` properties are optional overrides and the user can use native UI fields (This still seems to work in DBeaver 25.3). Should this ever stop working, the override fields are there to help.

README documents the setup usage. Some tests added.

Tested with [AthenaJDBC42-2.0.34.1000.jar](https://github.com/AbsaOSS/simba-athena-login-service-support/releases/download/0.1.0/AthenaJDBC42-2.0.34.1000.jar)

Closes #https://github.com/absa-group/AUL/issues/3871